### PR TITLE
Add basic docker-compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3'
+services:
+  ruby:
+    build:
+      context: .
+      dockerfile: ./docker/ruby/Dockerfile
+    command: bin/rails s -p 3000 -b '0.0.0.0'
+    environment:
+      RAILS_ENV: development
+    volumes:
+      - .:/app
+    ports:
+      - "3000:3000"
+    # Allow support for irb, pry, etc
+    stdin_open: true
+    tty: true

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -1,0 +1,19 @@
+FROM ruby:2.1.5
+
+RUN apt-get update -qq
+
+# Defailt to /app directory
+RUN mkdir /app
+WORKDIR /app
+
+# Install gems
+COPY Gemfile /app/Gemfile
+COPY Gemfile.lock /app/Gemfile.lock
+RUN bundle install
+
+# Copy in application's source
+COPY . /app
+
+# Apply migrations
+RUN bin/rake db:migrate
+RUN bin/rake db:seed

--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -16,4 +16,3 @@ COPY . /app
 
 # Apply migrations
 RUN bin/rake db:migrate
-RUN bin/rake db:seed


### PR DESCRIPTION
This PR adds a very simple `docker-compose.yml` to make it easier to spin the application up locally.